### PR TITLE
Propagate process.env.NODE_TLS_REJECT_UNAUTHORIZED to openwhisk module.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,8 @@ function loadClient () {
     return openwhisk({
       api: `https://${props.apiHost}/api/v1/`,
       api_key: props.auth,
-      namespace: '_' // all activations live in the default namespace currently.
+      namespace: '_', // all activations live in the default namespace currently.
+      ignore_certs: process.env.NODE_TLS_REJECT_UNAUTHORIZED == "0"
     })
   }).catch(function (error) {
     console.error(`There was an error initializing the OpenWhisk client: ${error}.`)


### PR DESCRIPTION
Addresses #1 - not necessarily the best way to do this. Would prefer to pick up insecure property from wskprops file but it doesn't yet exist (opened issue against main repo to address).